### PR TITLE
docs: ドキュメントのアクセスURLとCORS設定を更新

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -110,8 +110,8 @@ curl http://localhost:18080/api/v1/health
 ```
 
 **Production access:**
-- Web UI: http://localhost:13000
-- API: http://localhost:18080/api/v1
+- Web UI: http://localhost:18000
+- API: http://localhost:18000/api/v1
 - Database: localhost:15432
 
 ##### Development Environment (For Developers)
@@ -128,8 +128,8 @@ curl http://localhost:18080/api/v1/health
 ```
 
 **Development access:**
-- Web UI: http://localhost:13000
-- API: http://localhost:18080/api/v1
+- Web UI: http://localhost:18000
+- API: http://localhost:18000/api/v1
 - Database: localhost:15432
 
 ##### Team Usage

--- a/README.md
+++ b/README.md
@@ -110,8 +110,8 @@ curl http://localhost:18080/api/v1/health
 ```
 
 **本番環境のアクセス:**
-- Web UI: http://localhost:13000
-- API: http://localhost:18080/api/v1
+- Web UI: http://localhost:18000
+- API: http://localhost:18000/api/v1
 - データベース: localhost:15432
 
 ##### 開発環境での起動（開発者向け）
@@ -128,8 +128,8 @@ curl http://localhost:18080/api/v1/health
 ```
 
 **開発環境のアクセス:**
-- Web UI: http://localhost:13000
-- API: http://localhost:18080/api/v1
+- Web UI: http://localhost:18000
+- API: http://localhost:18000/api/v1
 - データベース: localhost:15432
 
 ##### チーム運用での起動

--- a/config/environment.md
+++ b/config/environment.md
@@ -99,7 +99,7 @@ MCP_PROTECTED_METHODS=createRule,updateRule,deleteRule,createProject,updateProje
 ```bash
 # CORS Configuration
 CORS_ENABLED=true
-CORS_ALLOWED_ORIGINS=http://localhost:3000,http://localhost:13000,http://localhost:13001
+CORS_ALLOWED_ORIGINS=http://localhost:3000,http://localhost:13000,http://localhost:18000
 CORS_ALLOWED_METHODS=GET,POST,PUT,DELETE,OPTIONS
 CORS_ALLOWED_HEADERS=Content-Type,Authorization,X-API-Key
 ```

--- a/env.development.example
+++ b/env.development.example
@@ -26,7 +26,7 @@ DB_NAME=rulemcp
 JWT_SECRET=development-secret-key-change-in-production
 
 # CORS許可オリジン (開発環境用)
-ALLOWED_ORIGINS=http://localhost:3000,http://localhost:13000,http://localhost:18080
+ALLOWED_ORIGINS=http://localhost:3000,http://localhost:13000,http://localhost:18080,http://localhost:18000
 
 # =============================================================================
 # サーバー設定


### PR DESCRIPTION
- README.md（日本語版）: Web UIアクセスURLをlocalhost:18000に更新
- README.en.md（英語版）: Web UIアクセスURLをlocalhost:18000に更新
- config/environment.md: CORS_ALLOWED_ORIGINSにlocalhost:18000を追加
- env.development.example: ALLOWED_ORIGINSにlocalhost:18000を追加
- 本番環境・開発環境のアクセス方法を統一